### PR TITLE
Maintain HttpContext in the server CachingHandler

### DIFF
--- a/src/CacheCow.Server/CachingHandler.cs
+++ b/src/CacheCow.Server/CachingHandler.cs
@@ -416,12 +416,10 @@ namespace CacheCow.Server
 				if (_entityTagStore.TryGetValue(entityTagKey, out actualEtag))
 				{
 					isModified = actualEtag.LastModified > modifiedInQuestion;
+					if (isModified ^ ifModified)
+						return new NotModifiedResponse(actualEtag.ToEntityTagHeaderValue()).ToTask();
 				}
-
-				return isModified ^ ifModified
-						? new NotModifiedResponse(actualEtag.ToEntityTagHeaderValue()).ToTask()
-						: null;
-
+				return null;
 			};
 		}
 


### PR DESCRIPTION
The delegating `CachingHandler` didn't maintain [the synchronization context](http://msdn.microsoft.com/en-us/magazine/gg598924.aspx) when creating its continuation, so `HttpContext.Current` would be `null` in certain scenarios. This caused problems with my implementation of `IEntityTagStore` which depends on it.

I've verified that all unit tests still pass.
