### PR TITLE
PATCH Now invalidates cache

### DIFF
--- a/src/CacheCow.Server/CachingHandler.cs
+++ b/src/CacheCow.Server/CachingHandler.cs
@@ -284,7 +284,7 @@ namespace CacheCow.Server
 				() =>
 				{
 
-					if (!request.Method.Method.IsIn("PUT", "DELETE", "POST"))
+					if (!request.Method.Method.IsIn("PUT", "DELETE", "POST", "PATCH"))
 						return;
 
 					string uri = UriTrimmer(request.RequestUri);

--- a/test/CacheCow.Tests/Server/CachingHandlerTests.cs
+++ b/test/CacheCow.Tests/Server/CachingHandlerTests.cs
@@ -21,6 +21,7 @@ namespace CacheCow.Tests.Server
 		[TestCase("DELETE")]
 		[TestCase("PUT")]
 		[TestCase("POST")]
+		[TestCase("PATCH")]
 		public static void TestCacheInvalidation(string method)
 		{
 			// setup
@@ -30,9 +31,9 @@ namespace CacheCow.Tests.Server
 			var entityTagStore = mocks.StrictMock<IEntityTagStore>();
 			var linkedUrls = new []{"url1", "url2"};
 			var cachingHandler = new CachingHandler(entityTagStore)
-			                     	{
+									{
 										LinkedRoutePatternProvider = (url, mthd) => linkedUrls
-			                     	};
+									};
 			var entityTagKey = new CacheKey(TestUrl, new string[0], routePattern);
 			var response = new HttpResponseMessage();
 			var invalidateCache = cachingHandler.InvalidateCache(entityTagKey, request, response);
@@ -52,6 +53,7 @@ namespace CacheCow.Tests.Server
 
 		[TestCase("PUT")]
 		[TestCase("POST")]
+        [TestCase("PATCH")]
 		public static void TestCacheInvalidationForPost(string method)
 		{
 			// setup


### PR DESCRIPTION
Problem: Making PATCH requests to API does not invalidate cache.

Solution: Changed check in CachingHandler.InvalidateCache:

 if (!request.Method.Method.IsIn("PUT", "DELETE", "POST", "PATCH"))

Unit tests have been created which will fail if PATCH is not supported.
