### PR TITLE
Moved hardcoded SQL to stored procedure

### DIFF
--- a/src/CacheCow.Server.EntityTagStore.SqlServer/CacheCow.Server.EntityTagStore.SqlServer.csproj
+++ b/src/CacheCow.Server.EntityTagStore.SqlServer/CacheCow.Server.EntityTagStore.SqlServer.csproj
@@ -77,6 +77,7 @@
     <None Include="Scripts\AddUpdateCache.sp" />
     <None Include="Scripts\CacheState.tbl" />
     <None Include="Scripts\combine_scripts.bat" />
+    <None Include="Scripts\ClearCache.sp" />
     <None Include="Scripts\DeleteCacheById.sp" />
     <None Include="Scripts\DeleteCacheByRoutePattern.sp" />
     <None Include="Scripts\GetCache.sp" />

--- a/src/CacheCow.Server.EntityTagStore.SqlServer/Scripts/ClearCache.sp
+++ b/src/CacheCow.Server.EntityTagStore.SqlServer/Scripts/ClearCache.sp
@@ -1,0 +1,21 @@
+SET ANSI_NULLS ON
+GO
+SET QUOTED_IDENTIFIER ON
+GO
+
+IF  EXISTS (SELECT * FROM sys.objects WHERE object_id = OBJECT_ID(N'[dbo].[ClearCache]') AND type in (N'P', N'PC'))
+DROP PROCEDURE [dbo].[ClearCache]
+GO
+
+-- =============================================
+-- Author:		Carl Duguay
+-- Create date:	2013-07-10
+-- Description:	Removes all CacheKey records
+-- =============================================
+CREATE PROCEDURE ClearCache	 
+AS
+BEGIN
+	SET NOCOUNT OFF
+	DELETE FROM [dbo].[CacheState]
+END
+GO

--- a/src/CacheCow.Server.EntityTagStore.SqlServer/SqlServerEntityTagStore.cs
+++ b/src/CacheCow.Server.EntityTagStore.SqlServer/SqlServerEntityTagStore.cs
@@ -122,12 +122,10 @@ namespace CacheCow.Server.EntityTagStore.SqlServer
 			{
 				connection.Open();
 				command.Connection = connection;
-				command.CommandText = "DELETE FROM db.CacheState;";
-				command.CommandType = CommandType.Text;
+				command.CommandText = StoredProcedureNames.Clear;
+				command.CommandType = CommandType.StoredProcedure;
 				command.ExecuteNonQuery();
 			}
 		}
-
-
 	}
 }

--- a/src/CacheCow.Server.EntityTagStore.SqlServer/StoredProcedureNames.cs
+++ b/src/CacheCow.Server.EntityTagStore.SqlServer/StoredProcedureNames.cs
@@ -11,5 +11,6 @@ namespace CacheCow.Server.EntityTagStore.SqlServer
 		public static string AddUpdateCache = "AddUpdateCache";
 		public static string DeleteCacheById = "DeleteCacheById";
 		public static string DeleteCacheByRoutePattern = "DeleteCacheByRoutePattern";
+		public static string Clear = "ClearCache";
 	}
 }


### PR DESCRIPTION
Hi,

The `SqlServerEntityTagStore.Clear` method throws an `Invalid object name 'db.CacheState'` exception due to an invalid schema name.

I've moved the SQL from the class to a stored procedure and fixed the issue; let me know if you'd like any changes.

Thanks!
