### PR TITLE
Configure default schema for SQL Server cache

### DIFF
--- a/src/CacheCow.Server.EntityTagStore.SqlServer/SqlServerEntityTagStore.cs
+++ b/src/CacheCow.Server.EntityTagStore.SqlServer/SqlServerEntityTagStore.cs
@@ -35,15 +35,12 @@ namespace CacheCow.Server.EntityTagStore.SqlServer
 
 			}
 
-			this._connectionString = ConfigurationManager.ConnectionStrings[ConnectionStringName].ConnectionString;
 			this._schema = DefaultSchema;
+			this._connectionString = ConfigurationManager.ConnectionStrings[ConnectionStringName].ConnectionString;
 		}
 
 		public SqlServerEntityTagStore(string connectionString)
-		{
-			this._connectionString = connectionString;
-			this._schema = DefaultSchema;
-		}
+			: this(connectionString, DefaultSchema) {}
 
 		public SqlServerEntityTagStore(string connectionString, string schema)
 		{


### PR DESCRIPTION
The SQL Server cache adds everything to the `dbo` schema, which isn't allowed or desired in some environments. This pull request lets you optionally specify the schema to use with a constructor overload. Previous usage is unchanged.
