### PR TITLE
Removed unnecessary references from projects

### DIFF
--- a/src/CacheCow.Common/CacheCow.Common.csproj
+++ b/src/CacheCow.Common/CacheCow.Common.csproj
@@ -50,9 +50,6 @@
     <Reference Include="System.Net.Http.WebRequest, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.Net.Http.2.0.20710.0\lib\net40\System.Net.Http.WebRequest.dll</HintPath>
     </Reference>
-    <Reference Include="System.Web.Http, Version=4.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.AspNet.WebApi.Core.4.0.20505.0\lib\net40\System.Web.Http.dll</HintPath>
-    </Reference>
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="Microsoft.CSharp" />

--- a/src/CacheCow.Server.EntityTagStore.Memcached/CacheCow.Server.EntityTagStore.Memcached.csproj
+++ b/src/CacheCow.Server.EntityTagStore.Memcached/CacheCow.Server.EntityTagStore.Memcached.csproj
@@ -37,16 +37,10 @@
     <Reference Include="Enyim.Caching">
       <HintPath>..\..\packages\EnyimMemcached.2.12\lib\net35\Enyim.Caching.dll</HintPath>
     </Reference>
-    <Reference Include="Newtonsoft.Json">
-      <HintPath>..\..\packages\Newtonsoft.Json.4.5.11\lib\net40\Newtonsoft.Json.dll</HintPath>
-    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Net.Http, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.Net.Http.2.0.20710.0\lib\net40\System.Net.Http.dll</HintPath>
-    </Reference>
-    <Reference Include="System.Net.Http.Formatting, Version=4.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.AspNet.WebApi.Client.4.0.20710.0\lib\net40\System.Net.Http.Formatting.dll</HintPath>
     </Reference>
     <Reference Include="System.Net.Http.WebRequest, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.Net.Http.2.0.20710.0\lib\net40\System.Net.Http.WebRequest.dll</HintPath>

--- a/src/CacheCow.Server.EntityTagStore.Memcached/packages.config
+++ b/src/CacheCow.Server.EntityTagStore.Memcached/packages.config
@@ -1,7 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="EnyimMemcached" version="2.12" targetFramework="net40" />
-  <package id="Microsoft.AspNet.WebApi.Client" version="4.0.20710.0" targetFramework="net40" />
   <package id="Microsoft.Net.Http" version="2.0.20710.0" targetFramework="net40" />
-  <package id="Newtonsoft.Json" version="4.5.11" targetFramework="net40" />
 </packages>

--- a/src/CacheCow.Server.EntityTagStore.Memcached12/CacheCow.Server.EntityTagStore.Memcached12.csproj
+++ b/src/CacheCow.Server.EntityTagStore.Memcached12/CacheCow.Server.EntityTagStore.Memcached12.csproj
@@ -35,16 +35,10 @@
     <Reference Include="Enyim.Caching">
       <HintPath>..\..\lib\Enyim.Caching.dll</HintPath>
     </Reference>
-    <Reference Include="Newtonsoft.Json">
-      <HintPath>..\..\packages\Newtonsoft.Json.4.5.11\lib\net40\Newtonsoft.Json.dll</HintPath>
-    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Net.Http, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.Net.Http.2.0.20710.0\lib\net40\System.Net.Http.dll</HintPath>
-    </Reference>
-    <Reference Include="System.Net.Http.Formatting, Version=4.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.AspNet.WebApi.Client.4.0.30506.0\lib\net40\System.Net.Http.Formatting.dll</HintPath>
     </Reference>
     <Reference Include="System.Net.Http.WebRequest, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.Net.Http.2.0.20710.0\lib\net40\System.Net.Http.WebRequest.dll</HintPath>

--- a/src/CacheCow.Server.EntityTagStore.Memcached12/packages.config
+++ b/src/CacheCow.Server.EntityTagStore.Memcached12/packages.config
@@ -1,6 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.AspNet.WebApi.Client" version="4.0.30506.0" targetFramework="net40" />
   <package id="Microsoft.Net.Http" version="2.0.20710.0" targetFramework="net40" />
-  <package id="Newtonsoft.Json" version="4.5.11" targetFramework="net40" />
 </packages>

--- a/src/CacheCow.Server.EntityTagStore.MongoDb/CacheCow.Server.EntityTagStore.MongoDb.csproj
+++ b/src/CacheCow.Server.EntityTagStore.MongoDb/CacheCow.Server.EntityTagStore.MongoDb.csproj
@@ -42,7 +42,12 @@
     <Reference Include="System" />
     <Reference Include="System.Configuration" />
     <Reference Include="System.Core" />
-    <Reference Include="System.Net.Http" />
+    <Reference Include="System.Net.Http, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Net.Http.2.0.20710.0\lib\net40\System.Net.Http.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Net.Http.WebRequest, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Net.Http.2.0.20710.0\lib\net40\System.Net.Http.WebRequest.dll</HintPath>
+    </Reference>
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="Microsoft.CSharp" />

--- a/src/CacheCow.Server.EntityTagStore.MongoDb/packages.config
+++ b/src/CacheCow.Server.EntityTagStore.MongoDb/packages.config
@@ -1,4 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="Microsoft.Net.Http" version="2.0.20710.0" targetFramework="net40" />
   <package id="mongocsharpdriver" version="1.6.1" targetFramework="net40" />
+  <package id="System.Net.Http" version="2.0.20710.0" targetFramework="net40" />
 </packages>

--- a/src/CacheCow.Server.EntityTagStore.RavenDb/CacheCow.Server.EntityTagStore.RavenDb.csproj
+++ b/src/CacheCow.Server.EntityTagStore.RavenDb/CacheCow.Server.EntityTagStore.RavenDb.csproj
@@ -38,10 +38,6 @@
     <Reference Include="Microsoft.CompilerServices.AsyncTargetingPack.Net4">
       <HintPath>..\..\packages\Microsoft.CompilerServices.AsyncTargetingPack.1.0.1\lib\net40\Microsoft.CompilerServices.AsyncTargetingPack.Net4.dll</HintPath>
     </Reference>
-    <Reference Include="Newtonsoft.Json, Version=4.5.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\packages\Newtonsoft.Json.4.5.11\lib\net40\Newtonsoft.Json.dll</HintPath>
-    </Reference>
     <Reference Include="Raven.Abstractions">
       <HintPath>..\..\packages\RavenDB.Client.2.5.2750\lib\net40\Raven.Abstractions.dll</HintPath>
     </Reference>
@@ -54,9 +50,6 @@
     <Reference Include="System.Core" />
     <Reference Include="System.Net.Http, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.Net.Http.2.0.20710.0\lib\net40\System.Net.Http.dll</HintPath>
-    </Reference>
-    <Reference Include="System.Net.Http.Formatting, Version=4.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.AspNet.WebApi.Client.4.0.20710.0\lib\net40\System.Net.Http.Formatting.dll</HintPath>
     </Reference>
     <Reference Include="System.Net.Http.WebRequest, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.Net.Http.2.0.20710.0\lib\net40\System.Net.Http.WebRequest.dll</HintPath>

--- a/src/CacheCow.Server.EntityTagStore.RavenDb/packages.config
+++ b/src/CacheCow.Server.EntityTagStore.RavenDb/packages.config
@@ -1,8 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.AspNet.WebApi.Client" version="4.0.20710.0" targetFramework="net40" />
   <package id="Microsoft.CompilerServices.AsyncTargetingPack" version="1.0.1" targetFramework="net40" />
   <package id="Microsoft.Net.Http" version="2.0.20710.0" targetFramework="net40" />
-  <package id="Newtonsoft.Json" version="4.5.11" targetFramework="net40" />
   <package id="RavenDB.Client" version="2.5.2750" targetFramework="net40" />
 </packages>

--- a/src/CacheCow.Server.EntityTagStore.SqlServer/CacheCow.Server.EntityTagStore.SqlServer.csproj
+++ b/src/CacheCow.Server.EntityTagStore.SqlServer/CacheCow.Server.EntityTagStore.SqlServer.csproj
@@ -35,18 +35,11 @@
     <DocumentationFile>bin\Release\CacheCow.Server.EntityTagStore.SqlServer.XML</DocumentationFile>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Newtonsoft.Json, Version=4.5.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\packages\Newtonsoft.Json.4.5.11\lib\net40\Newtonsoft.Json.dll</HintPath>
-    </Reference>
     <Reference Include="System" />
     <Reference Include="System.configuration" />
     <Reference Include="System.Core" />
     <Reference Include="System.Net.Http, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.Net.Http.2.0.20710.0\lib\net40\System.Net.Http.dll</HintPath>
-    </Reference>
-    <Reference Include="System.Net.Http.Formatting, Version=4.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.AspNet.WebApi.Client.4.0.20710.0\lib\net40\System.Net.Http.Formatting.dll</HintPath>
     </Reference>
     <Reference Include="System.Net.Http.WebRequest, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.Net.Http.2.0.20710.0\lib\net40\System.Net.Http.WebRequest.dll</HintPath>

--- a/src/CacheCow.Server.EntityTagStore.SqlServer/packages.config
+++ b/src/CacheCow.Server.EntityTagStore.SqlServer/packages.config
@@ -1,6 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.AspNet.WebApi.Client" version="4.0.20710.0" targetFramework="net40" />
   <package id="Microsoft.Net.Http" version="2.0.20710.0" targetFramework="net40" />
-  <package id="Newtonsoft.Json" version="4.5.11" targetFramework="net40" />
 </packages>

--- a/src/CacheCow.Server/CacheCow.Server.csproj
+++ b/src/CacheCow.Server/CacheCow.Server.csproj
@@ -59,9 +59,6 @@
     <Reference Include="System.Web.Http, Version=4.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.AspNet.WebApi.Core.4.0.20710.0\lib\net40\System.Web.Http.dll</HintPath>
     </Reference>
-    <Reference Include="System.Web.Http.WebHost, Version=4.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.AspNet.WebApi.WebHost.4.0.30506.0\lib\net40\System.Web.Http.WebHost.dll</HintPath>
-    </Reference>
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="Microsoft.CSharp" />

--- a/src/CacheCow.Server/CachingHandler.cs
+++ b/src/CacheCow.Server/CachingHandler.cs
@@ -46,21 +46,11 @@ namespace CacheCow.Server
 
 		public bool AddVaryHeader { get; set; }
 
-		public CachingHandler(params string[] varyByHeader)
-			: this(new InMemoryEntityTagStore(), varyByHeader)
+		public CachingHandler(HttpConfiguration configuration, params string[] varyByHeader)
+			: this(configuration, new InMemoryEntityTagStore(), varyByHeader)
 		{
 
 		}
-
-        /// <summary>
-        /// Assumes Web host and uses GlobalConfiguration.Configuration
-        /// </summary>
-        /// <param name="entityTagStore"></param>
-        /// <param name="varyByHeaders"></param>
-	    public CachingHandler(IEntityTagStore entityTagStore, params string[] varyByHeaders)
-            : this(GlobalConfiguration.Configuration, entityTagStore, varyByHeaders)
-	    {
-	    }
 
 	    public CachingHandler(HttpConfiguration configuration, IEntityTagStore entityTagStore, params string[] varyByHeaders)
 		{

--- a/src/CacheCow.Server/packages.config
+++ b/src/CacheCow.Server/packages.config
@@ -2,7 +2,6 @@
 <packages>
   <package id="Microsoft.AspNet.WebApi.Client" version="4.0.20710.0" targetFramework="net40" />
   <package id="Microsoft.AspNet.WebApi.Core" version="4.0.20710.0" targetFramework="net40" />
-  <package id="Microsoft.AspNet.WebApi.WebHost" version="4.0.30506.0" targetFramework="net40" />
   <package id="Microsoft.Net.Http" version="2.0.20710.0" targetFramework="net40" />
   <package id="Microsoft.Web.Infrastructure" version="1.0.0.0" targetFramework="net40" />
   <package id="Newtonsoft.Json" version="4.5.11" targetFramework="net40" />

--- a/test/CacheCow.Client.FileCacheStore.Tests/CacheCow.Client.FileCacheStore.Tests.csproj
+++ b/test/CacheCow.Client.FileCacheStore.Tests/CacheCow.Client.FileCacheStore.Tests.csproj
@@ -108,6 +108,9 @@
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </Content>
   </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="$(SolutionDir)\.nuget\nuget.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 

--- a/test/CacheCow.Client.MemcachedCacheStore.Tests/CacheCow.Client.MemcachedCacheStore.Tests.csproj
+++ b/test/CacheCow.Client.MemcachedCacheStore.Tests/CacheCow.Client.MemcachedCacheStore.Tests.csproj
@@ -80,6 +80,9 @@
       <Name>CacheCow.Common</Name>
     </ProjectReference>
   </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="$(SolutionDir)\.nuget\nuget.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 

--- a/test/CacheCow.Client.RedisCacheStore.Tests/CacheCow.Client.RedisCacheStore.Tests.csproj
+++ b/test/CacheCow.Client.RedisCacheStore.Tests/CacheCow.Client.RedisCacheStore.Tests.csproj
@@ -78,6 +78,9 @@
   <ItemGroup>
     <None Include="packages.config" />
   </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="$(SolutionDir)\.nuget\nuget.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 

--- a/test/CacheCow.Client.SqlCacheStore.Tests/CacheCow.Client.SqlCacheStore.Tests.csproj
+++ b/test/CacheCow.Client.SqlCacheStore.Tests/CacheCow.Client.SqlCacheStore.Tests.csproj
@@ -78,6 +78,9 @@
       <Name>CacheCow.Common</Name>
     </ProjectReference>
   </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="$(SolutionDir)\.nuget\nuget.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 

--- a/test/CacheCow.Client.Tests/CacheCow.Client.Tests.csproj
+++ b/test/CacheCow.Client.Tests/CacheCow.Client.Tests.csproj
@@ -93,6 +93,9 @@
   <ItemGroup>
     <Content Include="Helper\Headers.txt" />
   </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="$(SolutionDir)\.nuget\nuget.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 

--- a/test/CacheCow.IntegrationTesting/CacheCow.IntegrationTesting.csproj
+++ b/test/CacheCow.IntegrationTesting/CacheCow.IntegrationTesting.csproj
@@ -82,6 +82,9 @@
       <Name>CacheCow.Server</Name>
     </ProjectReference>
   </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="$(SolutionDir)\.nuget\NuGet.targets" Condition="Exists('$(SolutionDir)\.nuget\NuGet.targets')" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 

--- a/test/CacheCow.LoadTesting/CacheCow.LoadTesting.csproj
+++ b/test/CacheCow.LoadTesting/CacheCow.LoadTesting.csproj
@@ -77,7 +77,9 @@
       <Name>CacheCow.Server</Name>
     </ProjectReference>
   </ItemGroup>
-  <ItemGroup />
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="$(SolutionDir)\.nuget\NuGet.targets" Condition="Exists('$(SolutionDir)\.nuget\NuGet.targets')" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 

--- a/test/CacheCow.LoadTesting/Server/WebApiConfig.cs
+++ b/test/CacheCow.LoadTesting/Server/WebApiConfig.cs
@@ -27,7 +27,7 @@ namespace CacheCow.LoadTesting.Server
             config.IncludeErrorDetailPolicy = IncludeErrorDetailPolicy.Always;
 
             config.Formatters.XmlFormatter.UseXmlSerializer = true;
-            var cachingHandler = new CachingHandler("Accept", "Accept-Encoding");
+            var cachingHandler = new CachingHandler(config, "Accept", "Accept-Encoding");
             cachingHandler.CacheControlHeaderProvider = new AttributeBasedCacheControlPolicy(new CacheControlHeaderValue()
                 {
                     NoCache = true, Private = true, NoStore = true

--- a/test/CacheCow.Server.EntityTagStore.Memcached.Tests/CacheCow.Server.EntityTagStore.Memcached.Tests.csproj
+++ b/test/CacheCow.Server.EntityTagStore.Memcached.Tests/CacheCow.Server.EntityTagStore.Memcached.Tests.csproj
@@ -82,6 +82,9 @@
   <ItemGroup>
     <None Include="packages.config" />
   </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="$(SolutionDir)\.nuget\nuget.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 

--- a/test/CacheCow.Server.EntityTagStore.RavenDb.Tests/CacheCow.Server.EntityTagStore.RavenDb.Tests.csproj
+++ b/test/CacheCow.Server.EntityTagStore.RavenDb.Tests/CacheCow.Server.EntityTagStore.RavenDb.Tests.csproj
@@ -100,6 +100,9 @@
       <Name>CacheCow.Common</Name>
     </ProjectReference>
   </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="$(SolutionDir)\.nuget\nuget.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 

--- a/test/CacheCow.Server.EntityTagStore.SqlServer.Tests/CacheCow.Server.EntityTagStore.SqlServer.Tests.csproj
+++ b/test/CacheCow.Server.EntityTagStore.SqlServer.Tests/CacheCow.Server.EntityTagStore.SqlServer.Tests.csproj
@@ -80,6 +80,9 @@
       <Name>CacheCow.Server.EntityTagStore.SqlServer</Name>
     </ProjectReference>
   </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="$(SolutionDir)\.nuget\nuget.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 

--- a/test/CacheCow.Tests/CacheCow.Tests.csproj
+++ b/test/CacheCow.Tests/CacheCow.Tests.csproj
@@ -99,7 +99,9 @@
       <Name>CacheCow.Server</Name>
     </ProjectReference>
   </ItemGroup>
-  <ItemGroup />
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="$(SolutionDir)\.nuget\nuget.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 

--- a/test/CacheCow.Tests/Server/CachingHandlerRulesTests.cs
+++ b/test/CacheCow.Tests/Server/CachingHandlerRulesTests.cs
@@ -13,6 +13,7 @@ using Rhino.Mocks;
 using Rhino.Mocks.Constraints;
 using Rhino.Mocks.Expectations;
 using Rhino.Mocks.Impl;
+using System.Web.Http;
 
 namespace CacheCow.Tests.Server
 {
@@ -34,7 +35,7 @@ namespace CacheCow.Tests.Server
 			// setup 
 			var mocks = new MockRepository();
 			var entityTagStore = mocks.StrictMock<IEntityTagStore>();
-			var entityTagHandler = new CachingHandler(entityTagStore);
+			var entityTagHandler = new CachingHandler(new HttpConfiguration(), entityTagStore);
 			var request = new HttpRequestMessage(HttpMethod.Get, TestUrl);
 			request.Headers.Add(headerName, values);
 			TimedEntityTagHeaderValue entityTagHeaderValue = new TimedEntityTagHeaderValue("\"12345678\"");
@@ -63,7 +64,7 @@ namespace CacheCow.Tests.Server
 		{
 			// setup
 			var request = new HttpRequestMessage(HttpMethod.Put, TestUrl);
-			var entityTagHandler = new CachingHandler();
+            var entityTagHandler = new CachingHandler(new HttpConfiguration());
 			var getRule = entityTagHandler.GetIfMatchNoneMatch();
 			
 			// run
@@ -80,7 +81,7 @@ namespace CacheCow.Tests.Server
 			var request = new HttpRequestMessage(HttpMethod.Get, TestUrl);
 			request.Headers.Add(HttpHeaderNames.IfMatch, "\"123\"");
 			request.Headers.Add(HttpHeaderNames.IfNoneMatch, "\"123\"");
-			var entityTagHandler = new CachingHandler();
+            var entityTagHandler = new CachingHandler(new HttpConfiguration());
 			var getRule = entityTagHandler.GetIfMatchNoneMatch();
 
 			// run
@@ -102,7 +103,7 @@ namespace CacheCow.Tests.Server
 			// setup 
 			var mocks = new MockRepository();
 			var entityTagStore = mocks.StrictMock<IEntityTagStore>();
-			var entityTagHandler = new CachingHandler(entityTagStore);
+			var entityTagHandler = new CachingHandler(new HttpConfiguration(), entityTagStore);
 			var request = new HttpRequestMessage(HttpMethod.Get, TestUrl);
 			DateTimeOffset lastChanged = DateTimeOffset.Now.Subtract(TimeSpan.FromDays(7));
 			DateTimeOffset lastModifiedInQuestion = resourceHasChanged
@@ -139,7 +140,7 @@ namespace CacheCow.Tests.Server
 		{
 			// setup
 			var request = new HttpRequestMessage(HttpMethod.Put, TestUrl);
-			var entityTagHandler = new CachingHandler();
+            var entityTagHandler = new CachingHandler(new HttpConfiguration());
 			var getRule = entityTagHandler.GetIfModifiedUnmodifiedSince();
 			// run
 			var task = getRule(request);
@@ -153,7 +154,7 @@ namespace CacheCow.Tests.Server
 		{
 			// setup
 			var request = new HttpRequestMessage(HttpMethod.Get, TestUrl);
-			var entityTagHandler = new CachingHandler();
+            var entityTagHandler = new CachingHandler(new HttpConfiguration());
 			var getRule = entityTagHandler.GetIfModifiedUnmodifiedSince();
 			// run
 			var task = getRule(request);
@@ -169,7 +170,7 @@ namespace CacheCow.Tests.Server
 			var request = new HttpRequestMessage(HttpMethod.Get, TestUrl);
 			request.Headers.Add(HttpHeaderNames.IfModifiedSince, DateTimeOffset.Now.ToString("r"));
 			request.Headers.Add(HttpHeaderNames.IfUnmodifiedSince, DateTimeOffset.Now.ToString("r"));
-			var entityTagHandler = new CachingHandler();
+            var entityTagHandler = new CachingHandler(new HttpConfiguration());
 			var getRule = entityTagHandler.GetIfModifiedUnmodifiedSince();
 
 			// run
@@ -190,7 +191,7 @@ namespace CacheCow.Tests.Server
 			// setup 
 			var mocks = new MockRepository();
 			var entityTagStore = mocks.StrictMock<IEntityTagStore>();
-			var entityTagHandler = new CachingHandler(entityTagStore);
+			var entityTagHandler = new CachingHandler(new HttpConfiguration(), entityTagStore);
 			var request = new HttpRequestMessage(HttpMethod.Put, TestUrl);
 			DateTimeOffset lastChanged = DateTimeOffset.Now.Subtract(TimeSpan.FromDays(7));
 			DateTimeOffset lastModifiedInQuestion = resourceHasChanged
@@ -232,7 +233,7 @@ namespace CacheCow.Tests.Server
 			// setup 
 			var mocks = new MockRepository();
 			var entityTagStore = mocks.StrictMock<IEntityTagStore>();
-			var entityTagHandler = new CachingHandler(entityTagStore);
+			var entityTagHandler = new CachingHandler(new HttpConfiguration(), entityTagStore);
 			var request = new HttpRequestMessage(HttpMethod.Put, TestUrl);
 			request.Headers.Add(HttpHeaderNames.IfMatch, values);
 			TimedEntityTagHeaderValue entityTagHeaderValue = new TimedEntityTagHeaderValue("\"12345678\"");
@@ -260,7 +261,7 @@ namespace CacheCow.Tests.Server
 		{
 			// setup
 			var request = new HttpRequestMessage(HttpMethod.Get, TestUrl);
-			var entityTagHandler = new CachingHandler();
+            var entityTagHandler = new CachingHandler(new HttpConfiguration());
 			var getRule = entityTagHandler.PutIfUnmodifiedSince();
 			// run
 			var task = getRule(request);
@@ -274,7 +275,7 @@ namespace CacheCow.Tests.Server
 		{
 			// setup
 			var request = new HttpRequestMessage(HttpMethod.Get, TestUrl);
-			var entityTagHandler = new CachingHandler();
+            var entityTagHandler = new CachingHandler(new HttpConfiguration());
 			var getRule = entityTagHandler.PutIfMatch();
 
 			// run

--- a/test/CacheCow.Tests/Server/CachingHandlerTests.cs
+++ b/test/CacheCow.Tests/Server/CachingHandlerTests.cs
@@ -16,6 +16,7 @@ using Rhino.Mocks;
 namespace CacheCow.Tests.Server
 {
     using System.IO;
+    using System.Web.Http;
 
     public class CachingHandlerTests
 	{
@@ -36,7 +37,7 @@ namespace CacheCow.Tests.Server
 			string routePattern = "http://myserver/api/stuffs/*";
 			var entityTagStore = mocks.StrictMock<IEntityTagStore>();
 			var linkedUrls = new []{"url1", "url2"};
-			var cachingHandler = new CachingHandler(entityTagStore)
+			var cachingHandler = new CachingHandler(new HttpConfiguration(), entityTagStore)
 									{
 										LinkedRoutePatternProvider = (url, mthd) => linkedUrls
 									};
@@ -67,7 +68,7 @@ namespace CacheCow.Tests.Server
 			string routePattern = "http://myserver/api/stuffs/*";
 			var entityTagStore = mocks.StrictMock<IEntityTagStore>();
 			var linkedUrls = new[] { "url1", "url2" };
-			var cachingHandler = new CachingHandler(entityTagStore)
+			var cachingHandler = new CachingHandler(new HttpConfiguration(), entityTagStore)
 			{
 				LinkedRoutePatternProvider = (url, mthd) => linkedUrls
 			};
@@ -96,7 +97,7 @@ namespace CacheCow.Tests.Server
             var request = new HttpRequestMessage(HttpMethod.Get, TestUrl);
             request.Headers.Add(HttpHeaderNames.Accept, "text/xml");
             var entityTagHeaderValue = new TimedEntityTagHeaderValue("\"12345678\"");
-            var cachingHandler = new CachingHandler()
+            var cachingHandler = new CachingHandler(new HttpConfiguration())
             {              
                 ETagValueGenerator = (x, y) => entityTagHeaderValue,
                 CacheControlHeaderProvider = (r, c) =>
@@ -134,7 +135,7 @@ namespace CacheCow.Tests.Server
 			request.Headers.Add(HttpHeaderNames.AcceptLanguage, "en-GB");
 			var entityTagStore = mocks.StrictMock<IEntityTagStore>();
 			var entityTagHeaderValue = new TimedEntityTagHeaderValue("\"12345678\"");
-			var cachingHandler = new CachingHandler(entityTagStore, varyByHeader)
+			var cachingHandler = new CachingHandler(new HttpConfiguration(), entityTagStore, varyByHeader)
 			{
 				AddLastModifiedHeader = addLastModifiedHeader,
 				AddVaryHeader = addVaryHeader,
@@ -196,7 +197,7 @@ namespace CacheCow.Tests.Server
             
             var entityTagStore = mocks.StrictMock<IEntityTagStore>();
             var linkedUrls = new[] { "url1", "url2" };
-            var cachingHandler = new CachingHandler(entityTagStore)
+            var cachingHandler = new CachingHandler(new HttpConfiguration(), entityTagStore)
             {
                 LinkedRoutePatternProvider = (url, mthd) => linkedUrls,
                 CacheKeyGenerator = (url, headers) =>


### PR DESCRIPTION
removed unnecessary references from projects. Especially the webapi webhost dependency on CacheCow.Server as we don't want system.web stuff in my OWIN application.

This introduces a breaking change but it's worth it IMHO.
