### PR TITLE
fix vary by param issue

### DIFF
--- a/src/CacheCow.Client/InMemoryVaryHeaderStore.cs
+++ b/src/CacheCow.Client/InMemoryVaryHeaderStore.cs
@@ -17,7 +17,7 @@ namespace CacheCow.Client
 		public bool TryGetValue(string uri, out IEnumerable<string> headers)
 		{
             headers = (string[])_cache.Get(uri);
-			return headers!=null;
+            return (!(headers == null || headers.ToArray().Length == 0));
 		}
 
 		public void AddOrUpdate(string uri, IEnumerable<string> headers)

--- a/test/CacheCow.Client.Tests/IntegrationTests.cs
+++ b/test/CacheCow.Client.Tests/IntegrationTests.cs
@@ -25,7 +25,8 @@ namespace CacheCow.Client.Tests
 													InnerHandler = new HttpClientHandler()
 												});
 
-			
+            httpClient.DefaultRequestHeaders.Add("Accept", "image/png");
+
 			var httpResponseMessage = httpClient.GetAsync(Url).Result;
 			var httpResponseMessage2 = httpClient.GetAsync(Url).Result;
 			var cacheCowHeader = httpResponseMessage2.Headers.GetCacheCowHeader();


### PR DESCRIPTION
I found an issue using the Accept header, it did not cache my responses

For CacheCow.Client.Tests.IntegrationTests.Test_GoogleImage

add adding httpClient.DefaultRequestHeaders.Add("Accept", "image/png"); 

breaks the test

this is because the following function

```
    public bool TryGetValue(string uri, out IEnumerable<string> headers)
    {
        headers = (string[])_cache.Get(uri);
        return headers!=null;
    }

assumes that headers is either a full array or null. In the scenario when subsequent requests are made with an Accepts header, the
variable 'headers' was found to be null for the 1st request, and and empty string array for the 2nd request.
Solution was to check for 'is null or empty array'
so :
    return headers!=null;
changed to :
    return (!(headers == null || headers.ToArray().Length == 0));
```
