### PR TITLE
Removed Microsoft.AspNet.WebApi.WebHost from CacheCow.Server package

### DIFF
--- a/src/CacheCow.Server/CacheCow.Server.nuspec
+++ b/src/CacheCow.Server/CacheCow.Server.nuspec
@@ -13,7 +13,6 @@
     <tags>aspnetwebapi http caching webapi cachecow etag</tags>
     <dependencies>
       <dependency id="CacheCow.Common" version="$version$" />
-      <dependency id="Microsoft.AspNet.WebApi.WebHost" version="4.0.30506.0"  />	  
     </dependencies>
   </metadata>
 </package>


### PR DESCRIPTION
It seems that CacheCow.Server doesn't need Microsoft.AspNet.WebApi.WebHost (it requires System.Web and is not so good) so I removed the dependency from the nugetspecs file.
