### PR TITLE
Support for latest version of mongocsharpdriver (v.1.10.0)

### DIFF
--- a/src/CacheCow.Server.EntityTagStore.MongoDb/DisposibleMongoConnection.cs
+++ b/src/CacheCow.Server.EntityTagStore.MongoDb/DisposibleMongoConnection.cs
@@ -12,7 +12,7 @@
 
         public MongoEntityStoreConnection(string connectionString, string databaseName = "EntityTagStore")
 		{
-			this.server = MongoServer.Create(connectionString);
+            this.server = new MongoClient(connectionString).GetServer();
             this.database = server.GetDatabase(databaseName);
 		}
 

--- a/src/CacheCow.Server.EntityTagStore.MongoDb/packages.config
+++ b/src/CacheCow.Server.EntityTagStore.MongoDb/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="mongocsharpdriver" version="1.6.1" targetFramework="net40" />
+  <package id="mongocsharpdriver" version="1.10.0" targetFramework="net40" />
 </packages>


### PR DESCRIPTION
The method MongoServer.Create() is deprecated and causes the following error on CollectionSave():
Method not found: 'MongoDB.Driver.SafeModeResult MongoDB.Driver.MongoCollection`1.Save(!0)'