### PR TITLE
Check for null response in ContentHashETagAttribute.

### DIFF
--- a/src/CacheCow.Server/ETagGeneration/ContentHashETagAttribute.cs
+++ b/src/CacheCow.Server/ETagGeneration/ContentHashETagAttribute.cs
@@ -16,7 +16,7 @@ namespace CacheCow.Server.ETagGeneration
         public override void OnActionExecuted(HttpActionExecutedContext actionExecutedContext)
         {
             base.OnActionExecuted(actionExecutedContext);
-            if(actionExecutedContext.Response.Content == null)
+            if(actionExecutedContext.Response == null || actionExecutedContext.Response.Content == null)
                 return;
 
             var bytes = actionExecutedContext.Response.Content


### PR DESCRIPTION
I added a null check for `actionExecutedContext.Response` to prevent a `NullReferenceException` when an exception is thrown by the action. It seems as if an action filter wouldn't be invoked on an exception, but my testing has shown otherwise unless I'm missing something.
