### PR TITLE
Pass content MD5 to the ETag generator in a request property.

### DIFF
--- a/src/CacheCow.Server/CachingHandler.cs
+++ b/src/CacheCow.Server/CachingHandler.cs
@@ -99,8 +99,7 @@ namespace CacheCow.Server
 		/// Default value is a function that generates a guid and URL is ignored and
 		/// it generates a weak ETag if no varyByHeaders is passed in
 		/// </summary>
-		public Func<string, IEnumerable<KeyValuePair<string, IEnumerable<string>>>,
-			EntityTagHeaderValue> ETagValueGenerator { get; set; }
+        public Func<HttpRequestMessage, HttpConfiguration, EntityTagHeaderValue> ETagValueGenerator { get; set; }
 
 		/// <summary>
 		/// This is a function that decides whether caching for a particular request
@@ -341,7 +340,7 @@ namespace CacheCow.Server
 						// create new ETag only if it does not already exist
 						if (!_entityTagStore.TryGetValue(cacheKey, out eTagValue))
 						{
-							eTagValue = new TimedEntityTagHeaderValue(ETagValueGenerator(uri, request.Headers));
+                            eTagValue = new TimedEntityTagHeaderValue(ETagValueGenerator(request, _configuration));
 							_entityTagStore.AddOrUpdate(cacheKey, eTagValue);
 						}
 

--- a/src/CacheCow.Server/ETagGeneration/ContentHashETagAttribute.cs
+++ b/src/CacheCow.Server/ETagGeneration/ContentHashETagAttribute.cs
@@ -12,7 +12,7 @@ namespace CacheCow.Server.ETagGeneration
     /// </summary>
     public class ContentHashETagAttribute : ActionFilterAttribute
     {
-        internal const string ContentHashHeaderName = "x-cachecow-content-hash-md5"; 
+        internal const string ContentHashPropertyName = "x-cachecow-content-hash-md5"; 
         public override void OnActionExecuted(HttpActionExecutedContext actionExecutedContext)
         {
             base.OnActionExecuted(actionExecutedContext);
@@ -27,7 +27,7 @@ namespace CacheCow.Server.ETagGeneration
                 var hash = md5.ComputeHash(bytes);
                 string hex = BitConverter.ToString(hash);
                 hex = hex.Replace("-", "");
-                actionExecutedContext.Request.Headers.TryAddWithoutValidation(ContentHashHeaderName, hex);
+                actionExecutedContext.Request.Properties.Add(ContentHashPropertyName, hex);
             }
         }       
     }

--- a/src/CacheCow.Server/ETagGeneration/ContentHashETagGenerator.cs
+++ b/src/CacheCow.Server/ETagGeneration/ContentHashETagGenerator.cs
@@ -1,8 +1,10 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Text;
+using System.Web.Http;
 
 namespace CacheCow.Server.ETagGeneration
 {
@@ -11,15 +13,16 @@ namespace CacheCow.Server.ETagGeneration
     /// </summary>
     public class ContentHashETagGenerator : DefaultETagGenerator
     {
-        public override EntityTagHeaderValue Generate(string url, 
-            IEnumerable<KeyValuePair<string, IEnumerable<string>>> requestHeaders)
+        public override EntityTagHeaderValue Generate(HttpRequestMessage request, HttpConfiguration configuration)
         {
-            var keyValuePair = requestHeaders.FirstOrDefault(x => 
-                x.Key == ContentHashETagAttribute.ContentHashHeaderName);
+            object hash;
 
-            
-            return keyValuePair.Key == null ? base.Generate(url, requestHeaders) :
-                new EntityTagHeaderValue("\"" + keyValuePair.Value.First() + "\"", false);
+            if (request.Properties.TryGetValue(ContentHashETagAttribute.ContentHashPropertyName, out hash))
+            {
+                return new EntityTagHeaderValue("\"" + hash + "\"", false);
+            }
+
+            return base.Generate(request, configuration);
         }
     }
 }

--- a/src/CacheCow.Server/ETagGeneration/DefaultETagGenerator.cs
+++ b/src/CacheCow.Server/ETagGeneration/DefaultETagGenerator.cs
@@ -1,8 +1,10 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Text;
+using System.Web.Http;
 
 namespace CacheCow.Server.ETagGeneration
 {
@@ -11,7 +13,7 @@ namespace CacheCow.Server.ETagGeneration
     /// </summary>
     public class DefaultETagGenerator : IETagGenerator
     {
-        public virtual EntityTagHeaderValue Generate(string url, IEnumerable<KeyValuePair<string, IEnumerable<string>>> requestHeaders)
+        public virtual EntityTagHeaderValue Generate(HttpRequestMessage request, HttpConfiguration configuration)
         {
             return new EntityTagHeaderValue(
                 string.Format("\"{0}\"", Guid.NewGuid().ToString("N").ToLower()),

--- a/src/CacheCow.Server/ETagGeneration/IETagGenerator.cs
+++ b/src/CacheCow.Server/ETagGeneration/IETagGenerator.cs
@@ -1,8 +1,6 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
+﻿using System.Net.Http;
 using System.Net.Http.Headers;
-using System.Text;
+using System.Web.Http;
 
 namespace CacheCow.Server.ETagGeneration
 {
@@ -11,6 +9,6 @@ namespace CacheCow.Server.ETagGeneration
     /// </summary>
     public interface IETagGenerator
     {
-        EntityTagHeaderValue Generate(string url, IEnumerable<KeyValuePair<string, IEnumerable<string>>> requestHeaders);
+        EntityTagHeaderValue Generate(HttpRequestMessage request, HttpConfiguration configuration);
     }
 }


### PR DESCRIPTION
In order to work around a possible null reference exception (see #119), I created an action filter attribute to generate an ETag to pass to the `ContentHashETagGenerator` class but felt awkward about  passing it in a request header. Upon further investigation, I noticed that the `CachingHandler` class passes the request and configuration objects to the various providers (i.e. `CacheControlHeaderProvider` and `CacheRefreshPolicyProvider`) and I thought it would be better to pass the MD5 in a request property and follow that convention.

I realize this is a breaking change for anyone that created a custom ETag generator based on the interface or existing classes, so if this is something you're interested I'll be happy to discus ways to make this backwards-compatible.