### PR TITLE
Prevent part of CacheCow.Client.InMemoryCacheStore.AddOrUpdate() runn…

### DIFF
--- a/src/CacheCow.Client/InMemoryCacheStore.cs
+++ b/src/CacheCow.Client/InMemoryCacheStore.cs
@@ -50,7 +50,7 @@ namespace CacheCow.Client
 			var req = response.RequestMessage;
 			response.RequestMessage = null;
 			var memoryStream = new MemoryStream();
-			Task.Factory.StartNew(() => _messageSerializer.SerializeAsync(TaskHelpers.FromResult(response), memoryStream)).Wait();
+			_messageSerializer.SerializeAsync(TaskHelpers.FromResult(response), memoryStream).Wait();
 			response.RequestMessage = req;
             _responseCache.Set(key.HashBase64, memoryStream.ToArray(), GetExpiry(response));
 		}


### PR DESCRIPTION
…ing on a different thread

When using Task.Factory.StartNew() for _messageSerializer.SerializeAsync(), sometimes _messageSerializer.SerializeAsync() will run on a separate thread.

When this happens, we experience either:

* when the item is not already in the cache, calling .Result on a HttpClient.GetAsync(url) task gives:
    "System.InvalidOperationException: The stream was already consumed. It cannot be read again."

* when the item in the cache, calling HttpClient.GetAsync(url) > System.Net.Http.HttpClient.SendAsync > System.Net.Http.HttpMessageInvoker.SendAsync > .Client.CachingHandler.SendAsync > CacheCow.Client.InMemoryCacheStore.TryGetValue() gives:
    "System.IO.IOException: Unexpected end of HTTP message stream. HTTP message is not complete.".

Removing the Task.Factory.StartNew() and just Wait()ing on the _messageSerializer.SerializeAsync() instead fixes this.