### PR TITLE
Fix for #142: Updating Date-header on NotModified stale client cache items

### DIFF
--- a/src/CacheCow.Client/CachingHandler.cs
+++ b/src/CacheCow.Client/CachingHandler.cs
@@ -82,7 +82,7 @@ namespace CacheCow.Client
                 var dateTimeOffset = response.Headers.Date;
 
                 TraceWriter.WriteLine(
-                    String.Format("CachedResponse date was => {0} - compraed to UTC.Now => {1}", dateTimeOffset, DateTimeOffset.UtcNow), TraceLevel.Verbose);
+                    String.Format("CachedResponse date was => {0} - compared to UTC.Now => {1}", dateTimeOffset, DateTimeOffset.UtcNow), TraceLevel.Verbose);
 
                 if (response.Content == null)
                     return ResponseValidationResult.NotCacheable;
@@ -262,7 +262,7 @@ namespace CacheCow.Client
             var cacheCowHeader = new CacheCowHeader();
             string uri = request.RequestUri.ToString();
 
-            TraceWriter.WriteLine("{0} - Starting", TraceLevel.Verbose, request.RequestUri.ToString());
+            TraceWriter.WriteLine("{0} - Starting SendAsync", TraceLevel.Verbose, request.RequestUri.ToString());
 
 
             // check if needs to be ignored
@@ -289,7 +289,7 @@ namespace CacheCow.Client
                 TraceWriter.WriteLine("{0} - Before TryGetValue", TraceLevel.Verbose, request.RequestUri.ToString());
 
                 cacheCowHeader.DidNotExist = !_cacheStore.TryGetValue(cacheKey, out cachedResponse);
-                TraceWriter.WriteLine("{0} - After TryGetValue", TraceLevel.Verbose, request.RequestUri.ToString());
+                TraceWriter.WriteLine("{0} - After TryGetValue: DidNotExist => {1}", TraceLevel.Verbose, request.RequestUri.ToString(), cacheCowHeader.DidNotExist);
 
                 if (!cacheCowHeader.DidNotExist.Value) // so if it EXISTS in cache
                 {
@@ -348,7 +348,7 @@ namespace CacheCow.Client
                 else
                 {
                     ExceptionHandler(ex);
-                    Trace.TraceWarning("Exception was swalloed in CacheCow: " + ex.ToString());
+                    Trace.TraceWarning("Exception was swallowed in CacheCow: " + ex.ToString());
                     return base.SendAsync(request, cancellationToken);
                 }
             }
@@ -424,7 +424,7 @@ namespace CacheCow.Client
                             // store the cache
                             _cacheStore.AddOrUpdate(cacheKey, serverResponse);
 
-                            TraceWriter.WriteLine("{0} - Before AddOrUpdate", TraceLevel.Verbose, request.RequestUri.ToString());
+                            TraceWriter.WriteLine("{0} - After AddOrUpdate", TraceLevel.Verbose, request.RequestUri.ToString());
 
 
                             break;

--- a/src/CacheCow.Client/CachingHandler.cs
+++ b/src/CacheCow.Client/CachingHandler.cs
@@ -477,14 +477,19 @@ namespace CacheCow.Client
             
             // update only if server had a cachecontrol.
             // TODO: merge CacheControl headers instead of replace
-            if (serverResponse.Headers.CacheControl != null && (!serverResponse.Headers.CacheControl.NoCache)) // added to cover issue #139
-            {
-                TraceWriter.WriteLine("CachingHandler.UpdateCachedResponse - CacheControl: " + serverResponse.Headers.CacheControl.ToString(), TraceLevel.Verbose);
-                cachedResponse.Headers.CacheControl = serverResponse.Headers.CacheControl;
-                cachedResponse.Headers.Date = DateTimeOffset.UtcNow; // very important
-                store.AddOrUpdate(cacheKey, cachedResponse);
-            }
-        }
+	        if (serverResponse.Headers.CacheControl != null && (!serverResponse.Headers.CacheControl.NoCache)) // added to cover issue #139
+	        {
+		        TraceWriter.WriteLine("CachingHandler.UpdateCachedResponse - CacheControl: " + serverResponse.Headers.CacheControl.ToString(), TraceLevel.Verbose);
+		        cachedResponse.Headers.CacheControl = serverResponse.Headers.CacheControl;
+	        }
+	        else
+	        {
+				TraceWriter.WriteLine("CachingHandler.UpdateCachedResponse - CacheControl missing from server. Applying sliding expiration. Date => " + DateTimeOffset.UtcNow, TraceLevel.Verbose);
+			}
+		
+			cachedResponse.Headers.Date = DateTimeOffset.UtcNow; // very important
+			store.AddOrUpdate(cacheKey, cachedResponse);
+		}
 
         private static void DoCacheValidationForGet(HttpRequestMessage request, CacheCowHeader cacheCowHeader,
             HttpResponseMessage cachedResponse)

--- a/test/CacheCow.Client.Tests/CachingHandlerTests.cs
+++ b/test/CacheCow.Client.Tests/CachingHandlerTests.cs
@@ -174,8 +174,8 @@ namespace CacheCow.Client.Tests
 			responseFromCache.Content.Headers.Expires = DateTime.Now.Subtract(TimeSpan.FromSeconds(10));
 			var responseFromServer = new HttpResponseMessage(HttpStatusCode.NotModified);
 			_messageHandler.Response = responseFromServer;
-			_cacheStore.Expect(x => x.TryGetValue(Arg<CacheKey>.Is.Anything,
-				  out Arg<HttpResponseMessage>.Out(responseFromCache).Dummy)).Return(true);
+			_cacheStore.Expect(x => x.TryGetValue(Arg<CacheKey>.Is.Anything, out Arg<HttpResponseMessage>.Out(responseFromCache).Dummy)).Return(true);
+			_cacheStore.Expect(x => x.AddOrUpdate(Arg<CacheKey>.Is.Anything, Arg<HttpResponseMessage>.Is.Anything));
 			
 			_mockRepository.ReplayAll();
 
@@ -208,8 +208,8 @@ namespace CacheCow.Client.Tests
 
 			var responseFromServer = new HttpResponseMessage(HttpStatusCode.NotModified);
 			_messageHandler.Response = responseFromServer;
-			_cacheStore.Expect(x => x.TryGetValue(Arg<CacheKey>.Is.Anything,
-				  out Arg<HttpResponseMessage>.Out(responseFromCache).Dummy)).Return(true);
+			_cacheStore.Expect(x => x.TryGetValue(Arg<CacheKey>.Is.Anything, out Arg<HttpResponseMessage>.Out(responseFromCache).Dummy)).Return(true);
+			_cacheStore.Expect(x => x.AddOrUpdate(Arg<CacheKey>.Is.Anything, Arg<HttpResponseMessage>.Is.Anything));
 
 			_mockRepository.ReplayAll();
 
@@ -334,7 +334,6 @@ namespace CacheCow.Client.Tests
             Assert.AreEqual(true, cacheCowHeader.CacheValidationApplied);
 
         }
-
 
         [Test]
         public void Get_NoMustRevalidate_NoMustRevalidateByDefault_Expires_GetFromCache()

--- a/test/CacheCow.IntegrationTesting/Server/TestController.cs
+++ b/test/CacheCow.IntegrationTesting/Server/TestController.cs
@@ -35,6 +35,7 @@ namespace CacheCow.IntegrationTesting.Server
 
     }
 
+
     public class ZeroMaxAgeController : ApiController
     {
         [HttpCacheControlPolicy(true, 0, noCache:false, nostore:false)]
@@ -56,7 +57,19 @@ namespace CacheCow.IntegrationTesting.Server
         {
 
         }
-
     }
 
+
+	public class NoMustRevalidateController : ApiController
+	{
+		[HttpCacheRefreshPolicy(10)]
+		[HttpCacheControlPolicy(false, 5, false)]
+		public string GetBigString()
+		{
+			var bytes = new byte[256 * 1024];
+			var random = new Random();
+			random.NextBytes(bytes);
+			return Convert.ToBase64String(bytes);
+		}
+	}
 }


### PR DESCRIPTION
This is a fix for issue #142, which best describes the bug and how to reproduce it.
Tests have been added to identify the bug, and to verify that the fix work.
And, the bug was fixed. It has been confirmed in our environment using the CacheCow.Client library.