### PR TITLE
TimedEntityTagHeader should parse RFC1123 date using Invariant culture.

### DIFF
--- a/src/CacheCow.Common/TimedEntityTagHeader.cs
+++ b/src/CacheCow.Common/TimedEntityTagHeader.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
 using System.Net.Http.Headers;
 using System.Text;
@@ -26,7 +27,7 @@ namespace CacheCow.Common
 		public TimedEntityTagHeaderValue(string tag, bool isWeak)
 			: base(tag, isWeak)
 		{
-			LastModified = DateTimeOffset.Parse(DateTimeOffset.UtcNow.ToString("r")); // to remove milliseconds
+			LastModified = DateTimeOffset.Parse(DateTimeOffset.UtcNow.ToString("r"), CultureInfo.InvariantCulture); // to remove milliseconds
 		}
 
 


### PR DESCRIPTION
Problem:

Our API automatically sets the culture based on the Accept-Language header. We noticed that API calls were failing for one of our customers who happened to be Italian and have their browser language to "it-IT".


Cause:

`TimedEntityTagHeader` generates a time stamp using the "r" format which always uses invariant culture (https://msdn.microsoft.com/en-us/library/az4se3k1(v=vs.110).aspx#RFC1123).

`DateTimeOffset.Parse` however uses the current culture unless otherwise specified. In the above scenario we effectively try and parse an invariant culture date using the Italian culture which throws an exception.

Fix:

Specify the Invariant culture when parsing.