### PR TITLE
Upgraded NEST to version 5.

### DIFF
--- a/src/CacheCow.Server.EntityTagStore.Elasticsearch/CacheCow.Server.EntityTagStore.Elasticsearch.csproj
+++ b/src/CacheCow.Server.EntityTagStore.Elasticsearch/CacheCow.Server.EntityTagStore.Elasticsearch.csproj
@@ -42,12 +42,17 @@
     <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Nest">
-      <HintPath>..\..\packages\NEST.0.12.0.0\lib\NET4\Nest.dll</HintPath>
+    <Reference Include="Elasticsearch.Net, Version=5.0.0.0, Culture=neutral, PublicKeyToken=96c599bbe3e70f5d, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Elasticsearch.Net.5.0.1\lib\net45\Elasticsearch.Net.dll</HintPath>
+      <Private>True</Private>
     </Reference>
-    <Reference Include="Newtonsoft.Json, Version=4.5.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\packages\Newtonsoft.Json.6.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
+    <Reference Include="Nest, Version=5.0.0.0, Culture=neutral, PublicKeyToken=96c599bbe3e70f5d, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\NEST.5.0.1\lib\net45\Nest.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Newtonsoft.Json, Version=9.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Newtonsoft.Json.9.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/src/CacheCow.Server.EntityTagStore.Elasticsearch/CacheCow.Server.EntityTagStore.Elasticsearch.nuspec
+++ b/src/CacheCow.Server.EntityTagStore.Elasticsearch/CacheCow.Server.EntityTagStore.Elasticsearch.nuspec
@@ -13,7 +13,7 @@
     <tags>aspnetwebapi http caching webapi cachecow elasticsearch etag</tags>
 	<dependencies>
       <dependency id="CacheCow.Server" version="$version$" />
-      <dependency id="NEST" version="0.12.0.0"  />
+      <dependency id="NEST" version="5.0.1"  />
 	  <dependency id="Newtonsoft.Json" version="6.0.3"  />
     </dependencies>
   </metadata>

--- a/src/CacheCow.Server.EntityTagStore.Elasticsearch/app.config
+++ b/src/CacheCow.Server.EntityTagStore.Elasticsearch/app.config
@@ -4,7 +4,7 @@
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
         <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-6.0.0.0" newVersion="6.0.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-9.0.0.0" newVersion="9.0.0.0" />
       </dependentAssembly>
     </assemblyBinding>
   </runtime>

--- a/src/CacheCow.Server.EntityTagStore.Elasticsearch/packages.config
+++ b/src/CacheCow.Server.EntityTagStore.Elasticsearch/packages.config
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="NEST" version="0.12.0.0" targetFramework="net45" />
-  <package id="Newtonsoft.Json" version="6.0.3" targetFramework="net45" />
+  <package id="Elasticsearch.Net" version="5.0.1" targetFramework="net45" />
+  <package id="NEST" version="5.0.1" targetFramework="net45" />
+  <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net45" />
 </packages>


### PR DESCRIPTION
The NEST-nuget has been upgraded.
Tested locally with ElasticSearch 5, and it seems to work as before.

Please don't forget to publish a new NuGet as well!
The .nuspec has been updated.