### PR TITLE
Deadlock fix

### DIFF
--- a/src/CacheCow.Client.RedisCacheStore/RedisStore.cs
+++ b/src/CacheCow.Client.RedisCacheStore/RedisStore.cs
@@ -90,7 +90,7 @@ namespace CacheCow.Client.RedisCacheStore
         {
             try
             {
-                return await DoGetValueAsync(key);
+                return await DoGetValueAsync(key).ConfigureAwait(false);
             }
             catch (Exception e)
             {
@@ -107,12 +107,12 @@ namespace CacheCow.Client.RedisCacheStore
             HttpResponseMessage result = null;
             string entryKey = key.HashBase64;
 
-            if (!await _database.KeyExistsAsync(entryKey))
+            if (!await _database.KeyExistsAsync(entryKey).ConfigureAwait(false))
                 return null;
 
-            byte[] value = await _database.StringGetAsync(entryKey);
+            byte[] value = await _database.StringGetAsync(entryKey).ConfigureAwait(false);
             var memoryStream = new MemoryStream(value);
-            var r = await _serializer.DeserializeToResponseAsync(memoryStream);
+            var r = await _serializer.DeserializeToResponseAsync(memoryStream).ConfigureAwait(false);
 
             return r;
         }
@@ -122,7 +122,7 @@ namespace CacheCow.Client.RedisCacheStore
         {
             try
             {
-                await DoAddOrUpdateAsync(key, response);
+                await DoAddOrUpdateAsync(key, response).ConfigureAwait(false);
             }
             catch(Exception e)
             {
@@ -136,7 +136,7 @@ namespace CacheCow.Client.RedisCacheStore
 	    private async Task<bool> DoAddOrUpdateAsync(CacheKey key, HttpResponseMessage response)
 	    {
             var memoryStream = new MemoryStream();
-            await _serializer.SerializeAsync(response, memoryStream);
+            await _serializer.SerializeAsync(response, memoryStream).ConfigureAwait(false);
             memoryStream.Position = 0;
             var data = memoryStream.ToArray();
             var expiry = response.GetExpiry() ?? DateTimeOffset.UtcNow.AddDays(1);
@@ -148,7 +148,7 @@ namespace CacheCow.Client.RedisCacheStore
                 expiry = minExpiry;
             }
 
-            await _database.StringSetAsync(key.HashBase64, data, expiry.Subtract(DateTimeOffset.UtcNow));
+            await _database.StringSetAsync(key.HashBase64, data, expiry.Subtract(DateTimeOffset.UtcNow)).ConfigureAwait(false);
             return true;
         }
 
@@ -157,7 +157,7 @@ namespace CacheCow.Client.RedisCacheStore
         {
             try
             {
-                return await DoTryRemoveAsync(key);
+                return await DoTryRemoveAsync(key).ConfigureAwait(false);
             }
             catch (Exception e)
             {

--- a/src/CacheCow.Client/CachingHandler.cs
+++ b/src/CacheCow.Client/CachingHandler.cs
@@ -260,7 +260,7 @@ namespace CacheCow.Client
 
             // check if needs to be ignored
             if (_ignoreRequestRules(request))
-                return await base.SendAsync(request, cancellationToken); // EXIT !! _________________
+                return await base.SendAsync(request, cancellationToken).ConfigureAwait(false); // EXIT !! _________________
 
             IEnumerable<string> varyHeaders;
             if (!VaryHeaderStore.TryGetValue(uri, out varyHeaders))
@@ -280,7 +280,7 @@ namespace CacheCow.Client
 
             TraceWriter.WriteLine("{0} - Before TryGetValue", TraceLevel.Verbose, request.RequestUri.ToString());
 
-            cachedResponse = await _cacheStore.GetValueAsync(cacheKey);
+            cachedResponse = await _cacheStore.GetValueAsync(cacheKey).ConfigureAwait(false);
             cacheCowHeader.DidNotExist = cachedResponse == null;
             TraceWriter.WriteLine("{0} - After TryGetValue: DidNotExist => {1}", TraceLevel.Verbose, request.RequestUri.ToString(), cacheCowHeader.DidNotExist);
 
@@ -301,7 +301,7 @@ namespace CacheCow.Client
                  ResponseValidationResult.OK, ResponseValidationResult.MustRevalidate))
             {
                 ApplyPutPatchDeleteValidationHeaders(request, cacheCowHeader, cachedResponse);
-                return await base.SendAsync(request, cancellationToken); // EXIT !! _____________________________
+                return await base.SendAsync(request, cancellationToken).ConfigureAwait(false); // EXIT !! _____________________________
             }
 
             // here onward is only GET only. See if cache OK and if it is then return
@@ -335,7 +335,7 @@ namespace CacheCow.Client
 
             // _______________________________ RESPONSE only GET  ___________________________________________
 
-            var serverResponse = await base.SendAsync(request, cancellationToken);
+            var serverResponse = await base.SendAsync(request, cancellationToken).ConfigureAwait(false);
 
             // HERE IS LATE FOR APPLYING EXCEPTION POLICY !!!
 
@@ -357,7 +357,7 @@ namespace CacheCow.Client
                 TraceWriter.WriteLine("{0} - NotModified",
                     TraceLevel.Verbose, request.RequestUri.ToString());
 
-                await UpdateCachedResponseAsync(cacheKey, cachedResponse, serverResponse, _cacheStore);
+                await UpdateCachedResponseAsync(cacheKey, cachedResponse, serverResponse, _cacheStore).ConfigureAwait(false);
                 ConsumeAndDisposeResponse(serverResponse);
                 return cachedResponse.AddCacheCowHeader(cacheCowHeader).CopyOtherCacheCowHeaders(serverResponse); // EXIT !! _______________
             }
@@ -397,7 +397,7 @@ namespace CacheCow.Client
 
                     // store the cache
                     CheckForCacheCowHeader(serverResponse);
-                    await _cacheStore.AddOrUpdateAsync(cacheKey, serverResponse);
+                    await _cacheStore.AddOrUpdateAsync(cacheKey, serverResponse).ConfigureAwait(false);
 
                     TraceWriter.WriteLine("{0} - After AddOrUpdate", TraceLevel.Verbose, request.RequestUri.ToString());
 
@@ -463,7 +463,7 @@ namespace CacheCow.Client
 
             cachedResponse.Headers.Date = DateTimeOffset.UtcNow; // very important
             CheckForCacheCowHeader(cachedResponse);
-            await store.AddOrUpdateAsync(cacheKey, cachedResponse);
+            await store.AddOrUpdateAsync(cacheKey, cachedResponse).ConfigureAwait(false);
         }
 
         private static void CheckForCacheCowHeader(HttpResponseMessage responseMessage)

--- a/src/CacheCow.Client/InMemoryCacheStore.cs
+++ b/src/CacheCow.Client/InMemoryCacheStore.cs
@@ -54,7 +54,7 @@ namespace CacheCow.Client
 	        if (result == null)
 	            return null;
 
-	        return (await _messageSerializer.DeserializeToResponseAsync(new MemoryStream((byte[]) result)));
+	        return await _messageSerializer.DeserializeToResponseAsync(new MemoryStream((byte[]) result)).ConfigureAwait(false);
 	    }
 
 	    public async Task AddOrUpdateAsync(CacheKey key, HttpResponseMessage response)
@@ -63,7 +63,7 @@ namespace CacheCow.Client
             var req = response.RequestMessage;
             response.RequestMessage = null;
             var memoryStream = new MemoryStream();
-	        await _messageSerializer.SerializeAsync(response, memoryStream);
+	        await _messageSerializer.SerializeAsync(response, memoryStream).ConfigureAwait(false);
             response.RequestMessage = req;
             var suggestedExpiry = response.GetExpiry() ?? DateTimeOffset.UtcNow.Add(_minExpiry);
             var minExpiry = DateTimeOffset.UtcNow.Add(_minExpiry);

--- a/src/CacheCow.Client/MessageContentHttpMessageSerializer.cs
+++ b/src/CacheCow.Client/MessageContentHttpMessageSerializer.cs
@@ -40,7 +40,7 @@ namespace CacheCow.Client
                 TraceWriter.WriteLine("SerializeAsync - before load",
                     TraceLevel.Verbose);
                 if(_bufferContent)
-                    await response.Content.LoadIntoBufferAsync();
+                    await response.Content.LoadIntoBufferAsync().ConfigureAwait(false);
                 TraceWriter.WriteLine("SerializeAsync - after load", TraceLevel.Verbose);               
             }
             else
@@ -59,11 +59,11 @@ namespace CacheCow.Client
         {
             if (request.Content != null && _bufferContent)
             {
-                await request.Content.LoadIntoBufferAsync();
+                await request.Content.LoadIntoBufferAsync().ConfigureAwait(false);
             }
 
             var httpMessageContent = new HttpMessageContent(request);
-            var buffer = await httpMessageContent.ReadAsByteArrayAsync();
+            var buffer = await httpMessageContent.ReadAsByteArrayAsync().ConfigureAwait(false);
             stream.Write(buffer, 0, buffer.Length);            
         }
 
@@ -74,9 +74,9 @@ namespace CacheCow.Client
             response.Content.Headers.Add("Content-Type", "application/http;msgtype=response");
             TraceWriter.WriteLine("before ReadAsHttpResponseMessageAsync",
                     TraceLevel.Verbose);
-            var responseMessage = await response.Content.ReadAsHttpResponseMessageAsync();
+            var responseMessage = await response.Content.ReadAsHttpResponseMessageAsync().ConfigureAwait(false);
             if (responseMessage.Content != null && _bufferContent)
-                await responseMessage.Content.LoadIntoBufferAsync(); 
+                await responseMessage.Content.LoadIntoBufferAsync().ConfigureAwait(false); 
             return responseMessage;
         }
 
@@ -85,9 +85,9 @@ namespace CacheCow.Client
             var request = new HttpRequestMessage();
             request.Content = new StreamContent(stream);
             request.Content.Headers.Add("Content-Type", "application/http;msgtype=request");
-            var requestMessage = await request.Content.ReadAsHttpRequestMessageAsync();
+            var requestMessage = await request.Content.ReadAsHttpRequestMessageAsync().ConfigureAwait(false);
             if (requestMessage.Content != null && _bufferContent)
-                await requestMessage.Content.LoadIntoBufferAsync();
+                await requestMessage.Content.LoadIntoBufferAsync().ConfigureAwait(false);
             return requestMessage;
         }
     }

--- a/src/CacheCow.Common/Helpers/BasicExtensions.cs
+++ b/src/CacheCow.Common/Helpers/BasicExtensions.cs
@@ -29,7 +29,7 @@ namespace CacheCow.Common.Helpers
             return async () =>
             {
                 foreach (var action in actions)
-                    await action();
+                    await action().ConfigureAwait(false);
             };
         }
 

--- a/src/CacheCow.Common/Helpers/HttpResponseMessageExtensions.cs
+++ b/src/CacheCow.Common/Helpers/HttpResponseMessageExtensions.cs
@@ -38,7 +38,7 @@ namespace CacheCow.Common.Helpers
                 }
                 else
                 {
-                    var error = await response.Content.ReadAsStringAsync();
+                    var error = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
                     throw new HttpRequestException($"Status: {response.StatusCode}\r\n Error: {error}");
                 }
             }


### PR DESCRIPTION
Fix deadlock on client side in applications that use UI SynchronizationContext (eg WPF, WinForms, ASP.NET (not net core)).

Example application with deadlock: [CacheCowDeadlockTest.zip](https://github.com/aliostad/CacheCow/files/2191896/CacheCowDeadlockTest.zip)

Fix:
Use ConfigureAwait(false) for all awaited async methods.
More information: https://blog.stephencleary.com/2012/07/dont-block-on-async-code.html
