### PR TITLE
Add editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,142 @@
+###############################
+# Core EditorConfig Options   #
+###############################
+
+root = true
+
+# All files
+[*]
+indent_style = space
+
+# Code files
+[*.{cs,csx,vb,vbx}]
+indent_size          = 4
+insert_final_newline = true
+charset              = utf-8-bom
+
+###############################
+# .NET Coding Conventions     #
+###############################
+
+[*.{cs,vb}]
+# Organize usings
+dotnet_sort_system_directives_first                               = true
+
+# this. preferences
+dotnet_style_qualification_for_field                              = false : none
+dotnet_style_qualification_for_property                           = false : none
+dotnet_style_qualification_for_method                             = false : none
+dotnet_style_qualification_for_event                              = false : none
+
+# Language keywords vs BCL types preferences
+dotnet_style_predefined_type_for_locals_parameters_members        = true : none
+dotnet_style_predefined_type_for_member_access                    = true : none
+
+# Parentheses preferences
+dotnet_style_parentheses_in_arithmetic_binary_operators           = always_for_clarity : silent
+dotnet_style_parentheses_in_relational_binary_operators           = always_for_clarity : silent
+dotnet_style_parentheses_in_other_binary_operators                = always_for_clarity : silent
+dotnet_style_parentheses_in_other_operators                       = never_if_unnecessary : silent
+
+# Modifier preferences
+dotnet_style_require_accessibility_modifiers                      = for_non_interface_members : none
+dotnet_style_readonly_field                                       = true : suggestion
+
+# Expression-level preferences
+dotnet_style_object_initializer                                   = true : suggestion
+dotnet_style_collection_initializer                               = true : suggestion
+dotnet_style_explicit_tuple_names                                 = true : suggestion
+dotnet_style_null_propagation                                     = true : suggestion
+dotnet_style_coalesce_expression                                  = true : suggestion
+dotnet_style_prefer_is_null_check_over_reference_equality_method  = true : silent
+dotnet_prefer_inferred_tuple_names                                = true : suggestion
+dotnet_prefer_inferred_anonymous_type_member_names                = true : suggestion
+dotnet_style_prefer_auto_properties                               = true : silent
+dotnet_style_prefer_conditional_expression_over_assignment        = true : silent
+dotnet_style_prefer_conditional_expression_over_return            = true : silent
+
+###############################
+# Naming Conventions          #
+###############################
+
+# Style Definitions
+dotnet_naming_style.pascal_case_style.capitalization              = pascal_case
+
+# Use PascalCase for constant fields
+dotnet_naming_rule.constant_fields_should_be_pascal_case.severity = suggestion
+dotnet_naming_rule.constant_fields_should_be_pascal_case.symbols  = constant_fields
+dotnet_naming_rule.constant_fields_should_be_pascal_case.style    = pascal_case_style
+dotnet_naming_symbols.constant_fields.applicable_kinds            = field
+dotnet_naming_symbols.constant_fields.applicable_accessibilities  = *
+dotnet_naming_symbols.constant_fields.required_modifiers          = const
+
+###############################
+# C# Coding Conventions       #
+###############################
+
+[*.cs]
+# var preferences
+csharp_style_var_for_built_in_types                                      = true : none
+csharp_style_var_when_type_is_apparent                                   = true : none
+csharp_style_var_elsewhere                                               = true : none
+
+# Expression-bodied members
+csharp_style_expression_bodied_methods                                   = false : none
+csharp_style_expression_bodied_constructors                              = false : none
+csharp_style_expression_bodied_operators                                 = false : none
+csharp_style_expression_bodied_properties                                = true : none
+csharp_style_expression_bodied_indexers                                  = true : none
+csharp_style_expression_bodied_accessors                                 = true : none
+
+# Pattern matching preferences
+csharp_style_pattern_matching_over_is_with_cast_check                    = true : suggestion
+csharp_style_pattern_matching_over_as_with_null_check                    = true : suggestion
+
+# Null-checking preferences
+csharp_style_throw_expression                                            = true : suggestion
+csharp_style_conditional_delegate_call                                   = true : suggestion
+
+# Modifier preferences
+csharp_preferred_modifier_order                                          = public,private,protected,internal,static,extern,new,virtual,abstract,sealed,override,readonly,unsafe,volatile,async : suggestion
+
+# Expression-level preferences
+csharp_prefer_braces                                                     = true : none
+csharp_style_deconstructed_variable_declaration                          = true : suggestion
+csharp_prefer_simple_default_expression                                  = true : suggestion
+csharp_style_pattern_local_over_anonymous_function                       = true : suggestion
+csharp_style_inlined_variable_declaration                                = true : suggestion
+
+###############################
+# C# Formatting Rules         #
+###############################
+
+# New line preferences
+csharp_new_line_before_open_brace                                        = all
+csharp_new_line_before_else                                              = true
+csharp_new_line_before_catch                                             = true
+csharp_new_line_before_finally                                           = true
+csharp_new_line_before_members_in_object_initializers                    = true
+csharp_new_line_before_members_in_anonymous_types                        = true
+csharp_new_line_between_query_expression_clauses                         = true
+
+# Indentation preferences
+csharp_indent_case_contents                                              = true
+csharp_indent_switch_labels                                              = true
+csharp_indent_labels                                                     = flush_left
+
+# Space preferences
+csharp_space_after_cast                                                  = false
+csharp_space_after_keywords_in_control_flow_statements                   = true
+csharp_space_between_method_call_parameter_list_parentheses              = false
+csharp_space_between_method_declaration_parameter_list_parentheses       = false
+csharp_space_between_parentheses                                         = false
+csharp_space_before_colon_in_inheritance_clause                          = true
+csharp_space_after_colon_in_inheritance_clause                           = true
+csharp_space_around_binary_operators                                     = before_and_after
+csharp_space_between_method_declaration_empty_parameter_list_parentheses = false
+csharp_space_between_method_call_name_and_opening_parenthesis            = false
+csharp_space_between_method_call_empty_parameter_list_parentheses        = false
+
+# Wrapping preferences
+csharp_preserve_single_line_statements                                   = true
+csharp_preserve_single_line_blocks                                       = true

--- a/.editorconfig
+++ b/.editorconfig
@@ -10,9 +10,10 @@ indent_style = space
 
 # Code files
 [*.{cs,csx,vb,vbx}]
-indent_size          = 4
-insert_final_newline = true
-charset              = utf-8-bom
+indent_size              = 4
+insert_final_newline     = true
+charset                  = utf-8-bom
+trim_trailing_whitespace = true
 
 ###############################
 # .NET Coding Conventions     #

--- a/CacheCow.sln
+++ b/CacheCow.sln
@@ -30,6 +30,11 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "CacheCow.Server.WebApi", "s
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "CacheCow.Server", "src\CacheCow.Server\CacheCow.Server.csproj", "{DA077137-70D7-4CD4-B817-E852AFCAB30B}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{AABDC20F-A952-4842-B56F-03433FB2F3A0}"
+	ProjectSection(SolutionItems) = preProject
+		.editorconfig = .editorconfig
+	EndProjectSection
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU


### PR DESCRIPTION
 As discussed in issue #215 I've added a sample editorconfig.

I used the example editorconfig from the official documentation as a starting point.
https://docs.microsoft.com/en-us/visualstudio/ide/editorconfig-code-style-settings-reference?view=vs-2017#example-editorconfig-file
The only rule I added was to trim the trailing whitespace.

Running code format in any of the solutions should now enforce consistent brace and indentation styles.

At the moment the editorconfig is also a solution item in the CacheCow solution, but I should probably revert that change as the editorconfig shouldn't be edited once configured.

Other possible editorconfig reference could be the one from the .NET Core team: https://github.com/dotnet/corefx/blob/master/.editorconfig

Currently the entire configuration is silent or suggestion only, but if there are certain rules that should be more strictly enforced this can be raised to warning/error.