### PR TITLE
Fixing a deadlock + workaround for serialization

### DIFF
--- a/src/CacheCow.Client.FileCacheStore/FileStore.cs
+++ b/src/CacheCow.Client.FileCacheStore/FileStore.cs
@@ -46,7 +46,7 @@ namespace CacheCow.Client.FileCacheStore
             if (cacheRoot is null || ForbiddenDirectories.Contains(cacheRoot))
             {
                 throw new ArgumentException(
-                    "The given cachedirectory is null or invalid. Do give an explicit caching directory, not empty, '/' or '.'. This will prevent accidents when cleaning the cache");
+                    "The given caching directory is null or invalid. Do give an explicit caching directory, not empty, '/' or '.'. This will prevent accidents when cleaning the cache");
             }
 
             _cacheRoot = cacheRoot;
@@ -73,6 +73,24 @@ namespace CacheCow.Client.FileCacheStore
         /// <inheritdoc />
         public async Task AddOrUpdateAsync(CacheKey key, HttpResponseMessage response)
         {
+            /*
+             * TODO Fix this when upstream fixes the issue
+             * So, as it turns out, there is some bug in HttpResponseMessage.
+             * Deserializing does not work well and crashes on the 'Server' header.
+             *
+             * Not so useful thus....
+             *
+             * As a workaround, I throw away the server-header.
+             * Lets be honest, in 99%, we don't really care where it was hosted.
+             *
+             * See issues:
+             * https://github.com/aliostad/CacheCow/issues/213
+             * https://github.com/dotnet/corefx/issues/31918
+             * https://github.com/aspnet/AspNetWebStack/issues/193#issuecomment-418529386
+             */
+
+            response.Headers.Remove("Server");
+
             using (var fs = File.OpenWrite(_pathFor(key)))
             {
                 await _serializer.SerializeAsync(response, fs);
@@ -80,21 +98,17 @@ namespace CacheCow.Client.FileCacheStore
         }
 
         /// <inheritdoc />
-        public Task<bool> TryRemoveAsync(CacheKey key)
+        public async Task<bool> TryRemoveAsync(CacheKey key)
         {
-            return new Task<bool>(() =>
-                {
-                    if (!File.Exists(_pathFor(key)))
+            if (!File.Exists(_pathFor(key)))
+            {
+                return false;
+            }
 
-                    {
-                        return false;
-                    }
-
-                    File.Delete(_pathFor(key));
-                    return true;
-                }
-            );
+            File.Delete(_pathFor(key));
+            return true;
         }
+
 
         /// <inheritdoc />
         public async Task ClearAsync()
@@ -105,13 +119,11 @@ namespace CacheCow.Client.FileCacheStore
             }
         }
 
-
         private string _pathFor(CacheKey key)
         {
             // Base64 might return "/" as character. This breaks files; so we replace the '/' with '!'
             return _cacheRoot + "/" + key.HashBase64.Replace('/', '!');
         }
-
 
         /// <inheritdoc />
         public void Dispose()

--- a/test/CacheCow.Client.FileCacheStore.Tests/TestFileStore.cs
+++ b/test/CacheCow.Client.FileCacheStore.Tests/TestFileStore.cs
@@ -10,7 +10,6 @@ namespace CacheCow.Client.FileCacheStore.Tests
     /// </summary>
     public class TestFileStore
     {
-
         private readonly ITestOutputHelper _output;
 
         public TestFileStore(ITestOutputHelper output)
@@ -36,9 +35,12 @@ namespace CacheCow.Client.FileCacheStore.Tests
             var client = fs.CreateClient();
             Assert.True(fs.IsEmpty());
             log("Querying...");
-            var response = client.GetAsync(new Uri("https://www.example.org/")).ConfigureAwait(false).GetAwaiter().GetResult();
+            var uri = new Uri("https://www.example.com");
+            var response = client.GetAsync(uri).ConfigureAwait(false).GetAwaiter()
+                .GetResult();
             Assert.False(fs.IsEmpty());
-            var cachedResponse = client.GetAsync(new Uri("https://www.example.org/")).ConfigureAwait(false).GetAwaiter()
+            var cachedResponse = client.GetAsync(uri).ConfigureAwait(false)
+                .GetAwaiter()
                 .GetResult();
 
 
@@ -48,6 +50,24 @@ namespace CacheCow.Client.FileCacheStore.Tests
 
             fs.ClearAsync().ConfigureAwait(false).GetAwaiter().GetResult();
             Assert.True(fs.IsEmpty());
+        }
+
+        /// <summary>
+        ///
+        /// </summary>
+        [Fact]
+        public void TestLoad404()
+        {
+            var fs = new FileStore("cache");
+            fs.ClearAsync().ConfigureAwait(false).GetAwaiter().GetResult();
+            var client = fs.CreateClient();
+
+
+            var response = client.GetAsync(new Uri("https://www.openstreetmap.org/non-existin-page"))
+                .ConfigureAwait(false).GetAwaiter()
+                .GetResult();
+
+            Assert.Equal("NotFound", "" + response.StatusCode);
         }
     }
 }


### PR DESCRIPTION
Hey Aliostad,

I've been using the FileStore now for some time in my own code, which surfaced some bugs. This PR solves them for everyone who'd like to use the FileStore.

The first bug was a deadlock in my filestore, related to (an attempt to) delete files.
Weirdly, this bug only roared its head on invalid pages.

The second change is a workaround for an upstream bug relating to the HttpMessageContent-serialization stuff. It turns out that the deserialization can't handle the Server-header. I've added a workaround (not serializing the server-header) so that this works. The work-around is documented in the code.

So, if you have any remarks, let them now. I'll resolve them on monday when I'm working again.