### PR TITLE
Include the value of the "Range" header in the cache key

### DIFF
--- a/src/CacheCow.Client/CachingHandler.cs
+++ b/src/CacheCow.Client/CachingHandler.cs
@@ -49,7 +49,7 @@ namespace CacheCow.Client
             UseConditionalPutPatchDelete = true;
             MustRevalidateByDefault = true;
             VaryHeaderStore = varyHeaderStore;
-            DefaultVaryHeaders = new string[] { HttpHeaderNames.Accept };
+            DefaultVaryHeaders = new string[] { HttpHeaderNames.Accept, HttpHeaderNames.Range };
             ResponseValidator = (response) =>
             {
                 // 13.4
@@ -411,9 +411,9 @@ namespace CacheCow.Client
                     // re-create cacheKey with real server accept
 
                     // if there is a vary header, store it
-                    if (serverResponse.Headers.Vary != null)
+                    if (serverResponse.Headers.Vary?.Any() ?? false)
                     {
-                        varyHeaders = serverResponse.Headers.Vary.Select(x => x).ToArray();
+                        varyHeaders = serverResponse.Headers.Vary.Select(x => x).Concat(varyHeaders).Distinct(StringComparer.CurrentCultureIgnoreCase).ToArray();
                         IEnumerable<string> temp;
                         if (!VaryHeaderStore.TryGetValue(uri, out temp))
                         {

--- a/src/CacheCow.Common/HttpHeaderNames.cs
+++ b/src/CacheCow.Common/HttpHeaderNames.cs
@@ -15,6 +15,7 @@
         public const string IfUnmodifiedSince = "If-Unmodified-Since";
         public const string Vary = "Vary";
         public const string Pragma = "Pragma";
+        public const string Range = "Range";
         public const string Expires = "Expires";
         public const string SetCookie = "Set-Cookie";
     }


### PR DESCRIPTION
This is required for the caching handler to properly work with partial HTTP requests using the "Range" header. Without including the range in the cache key, the partial content stored first for a given URI would always be retrieved from the cache.

A test was added to ensure that two requests to the same URI with different ranges produce two entires in the cache.