### PR TITLE
Observe the `DefaultVaryHeaders` when creating the cache key

### DIFF
--- a/src/CacheCow.Client/CachingHandler.cs
+++ b/src/CacheCow.Client/CachingHandler.cs
@@ -411,9 +411,9 @@ namespace CacheCow.Client
                     // re-create cacheKey with real server accept
 
                     // if there is a vary header, store it
-                    if (serverResponse.Headers.Vary != null)
+                    if (serverResponse.Headers.Vary?.Any() ?? false)
                     {
-                        varyHeaders = serverResponse.Headers.Vary.Select(x => x).ToArray();
+                        varyHeaders = serverResponse.Headers.Vary.Select(x => x).Concat(varyHeaders).Distinct(StringComparer.CurrentCultureIgnoreCase).ToArray();
                         IEnumerable<string> temp;
                         if (!VaryHeaderStore.TryGetValue(uri, out temp))
                         {

--- a/test/CacheCow.Client.Tests/CachingHandlerTests.cs
+++ b/test/CacheCow.Client.Tests/CachingHandlerTests.cs
@@ -568,9 +568,36 @@ namespace CacheCow.Client.Tests
 
         }
 
+        [Theory]
+        [InlineData(CacheablePublicResource, true)]
+        [InlineData("https://datatracker.ietf.org/doc/html/rfc7234", false)]
+        public async Task IncludeRangeHeaderInCacheKey(string url, bool hasVaryHeader)
+        {
+            var cacheStore = new DictionaryBasedCache();
+            var cachingHandler = new CachingHandler(cacheStore) { DefaultVaryHeaders = new[] { "Range" }, InnerHandler = new HttpClientHandler() };
+            var client = new HttpClient(cachingHandler);
+
+            var request1 = new HttpRequestMessage(HttpMethod.Get, url)
+            {
+                Headers = { Range = new RangeHeaderValue(from: 0, to: 15) }
+            };
+            var request2 = new HttpRequestMessage(HttpMethod.Get, url)
+            {
+                Headers = { Range = new RangeHeaderValue(from: 16, to: 31) }
+            };
+            var response1 = await client.SendAsync(request1);
+            var response2 = await client.SendAsync(request2);
+
+            Assert.Equal(hasVaryHeader, response1.Headers.Vary.Any());
+            Assert.Equal(hasVaryHeader, response2.Headers.Vary.Any());
+            Assert.Equal(2, cacheStore.Count);
+        }
+
         class DictionaryBasedCache : ICacheStore
         {
             private Dictionary<string, HttpResponseMessage> _cache = new Dictionary<string, HttpResponseMessage>();
+
+            public int Count => _cache.Count;
 
             public void Dispose()
             {


### PR DESCRIPTION
If the server replies with a `Vary` header then the `DefaultVaryHeaders` are not used when computing the cache key.

The new `IncludeRangeHeaderInCacheKey` test demonstrates this issue and ensure it's fixed.

This is a followup to #268