### PR TITLE
Truncate existing cache file

### DIFF
--- a/src/CacheCow.Client.FileCacheStore/FileStore.cs
+++ b/src/CacheCow.Client.FileCacheStore/FileStore.cs
@@ -73,7 +73,7 @@ namespace CacheCow.Client.FileCacheStore
         /// <inheritdoc />
         public async Task AddOrUpdateAsync(CacheKey key, HttpResponseMessage response)
         {
-            using (var fs = File.OpenWrite(_pathFor(key)))
+            using (var fs = File.Open(_pathFor(key), FileMode.Create, FileAccess.Write, FileShare.None))
             {
                 await _serializer.SerializeAsync(response, fs);
             }


### PR DESCRIPTION
This PR fixes an issue with the FileStore, When a pre-existing cache file is overwritten it isn't truncated, this can result in an updated response having remnants of previous responses on the end.

I've replaced `File.OpenWrite` which uses `FileMode.OpenOrCreate` with `FileMode.Create` which will truncate the file if it exists.

Microsoft Docs: [System.IO.FileMode](https://docs.microsoft.com/en-us/dotnet/api/system.io.filemode?view=net-6.0#fields)