### PR TITLE
Fix the case where "Vary" header from response is never null

### DIFF
--- a/src/CacheCow.Client/CachingHandler.cs
+++ b/src/CacheCow.Client/CachingHandler.cs
@@ -411,7 +411,7 @@ namespace CacheCow.Client
                     // re-create cacheKey with real server accept
 
                     // if there is a vary header, store it
-                    if (serverResponse.Headers.Vary != null)
+                    if (serverResponse.Headers.Vary?.Any() ?? false)
                     {
                         varyHeaders = serverResponse.Headers.Vary.Select(x => x).ToArray();
                         IEnumerable<string> temp;


### PR DESCRIPTION
Following up with this [thread](https://github.com/aliostad/CacheCow/pull/269#issuecomment-1254377519),
this PR is to fix the bug in which `serverResponse.Headers.Vary` is not null but can be empty.
